### PR TITLE
JSC2: When using EB5, fail on mod files in GCCcore installs

### DIFF
--- a/eb_from_pr_upload_jsc-zen2.sh
+++ b/eb_from_pr_upload_jsc-zen2.sh
@@ -41,6 +41,10 @@ if [ $EB_REPO == "easybuild-easyblocks" ]; then
     repo_pr_arg='--include-easyblocks-from-pr'
 fi
 
+if [[ $EB_PREFIX == *"5.0.x"* ]]; then
+  export EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE=1
+fi
+
 module use $EASYBUILD_PREFIX/modules/all
 
 eb $repo_pr_arg $EB_PR --debug --rebuild --robot --upload-test-report --download-timeout=1000 $EB_ARGS


### PR DESCRIPTION
Requires:
* [ ] https://github.com/easybuilders/easybuild-framework/pull/4389
* [ ] JSC2 to have EB5 branch setup, with `5.0.x` in `EB_PREFIX`